### PR TITLE
refactor: 배포 파이프라인 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,39 @@
 name: Deploy to EC2
+
 on:
   push:
-    branches: [ develope ]
-env:
-  AWS_REGION: ap-northeast-2
-  REPO_URL: https://github.com/sooktin/backend_repository.git
+    branches: [ feature/autodeploy ]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     
     steps:
-    - name: Deploy to EC2 using git pull
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+        
+    - name: Build with Gradle
+      run: ./gradlew build -x test
+        
+    - name: Copy files to EC2
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ubuntu
+        key: ${{ secrets.EC2_SSH_KEY }}
+        source: "build/libs/*.jar,Dockerfile,docker-compose.yml,deploy.sh,nginx-default.conf"
+        target: "~/app"
+        strip_components: 0
+        
+    - name: Deploy to EC2
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.EC2_HOST }}
@@ -18,13 +41,5 @@ jobs:
         key: ${{ secrets.EC2_SSH_KEY }}
         script: |
           cd ~/app
-          git pull https://${{ secrets.GIT_USERNAME }}:${{ secrets.GIT_TOKEN }}@github.com/sooktin/backend_repository.git develope || echo "Git pull failed, but continuing deployment"  # main에서 develope로 변경
-          # 서버에 이미 Java가 있으면 아래 명령어를 실행할 수 있음
-          if command -v java &> /dev/null; then
-            chmod +x gradlew
-            ./gradlew build -x test
-          else
-            echo "Skipping Gradle build as Java is not available"
-          fi
           chmod +x deploy.sh
           ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [ feature/autodeploy ]
+    branches: [ develope ]
 
 jobs:
   deploy:


### PR DESCRIPTION
## 📌 이슈 번호

closed #68

## 💻 작업 내용

- [x]  배포 파이프라인을 Git Pull 방식에서 Git Push 방식으로 변경
- [x]  GitHub Actions에서 빌드 후 결과물만 EC2로 전송하도록 개선
- [x]  GitHub 토큰 의존성 제거로 보안 강화
- [x]  서버 리소스 사용 최적화 (서버에서 빌드 작업 제거)

### 변경 전/후 비교

- 변경 전: 서버에서 GitHub 토큰으로 코드를 pull 받고 빌드 수행
- 변경 후: GitHub Actions에서 빌드 후 SSH로 결과물만 서버에 전송

### 주요 개선점

1. 보안: GitHub 토큰 노출 제거
2. 효율성: 서버에서의 빌드 과정 제거로 리소스 절약
3. 안정성: 빌드와 배포 단계 명확히 분리
4. 속도: 필요한 파일만 전송하여 배포 시간 단축

## 📢 기타 사항

- 배포 시 특별히 확인이 필요한 사항은 없으나, 첫 배포에서 문제 발생 시 이전 방식으로 롤백 가능하도록 구성
- EC2_HOST와 EC2_SSH_KEY 시크릿 설정은 유지