### PR TITLE
fix: S3Config AWS 인증 설정 오류 수정

### DIFF
--- a/src/main/java/com/sooktin/backend/global/S3Config.java
+++ b/src/main/java/com/sooktin/backend/global/S3Config.java
@@ -12,13 +12,13 @@ import org.springframework.beans.factory.annotation.Value;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${aws.access-key}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secret-key}")
+    @Value("${aws.access-key}")
     private String secretKey;
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${aws.region}")
     private String region;
 
     @Bean


### PR DESCRIPTION
## 📌 이슈 번호
x

## 💻 작업 내용
- [x] S3Config 클래스의 AWS 인증 정보 참조 속성명 수정
- [x] AWS Parameter Store에 리전 정보 추가
- [x] 애플리케이션 배포 시 S3 서비스 연결 오류 해결

### 문제 원인
- `S3Config` 클래스에서 AWS 인증 정보를 `cloud.aws.credentials.xxx` 형식으로 참조하고 있었으나, Parameter Store에는 `aws.xxx` 형식으로 저장되어 있었습니다.
- 또한 리전 정보(`aws.region`)가 Parameter Store에 없어 오류가 발생했습니다.

### 해결 방법
1. S3Config 클래스에서 인증 정보 참조 속성명을 Parameter Store의 형식과 일치하도록 수정
   ```java
   // 변경 전
   @Value("${cloud.aws.credentials.access-key}")
   // 변경 후
   @Value("${aws.access-key}")

2. AWS Parameter Store에 리전 정보 추가
(access key, secret key는 이미 존재하기에 region정보만 추가)

3. S3Config 클래스에서 리전 정보 참조 수정

## 📢 기타 사항
- 향후 AWS 관련 설정 변수 네이밍 규칙을 aws.xxx 형식으로 통일하면 Parameter Store 값을 참조할 수 있으니 이렇게 설정 부탁드립니다! 
- 모든 환경 설정(리전 정보 포함)은 코드에 하드코딩하지 않고 Parameter Store에 저장하는 베스트 프랙티스를 따랐습니다 🙏🏼