### PR TITLE
fix: RabbitMQ AWS 인증 설정 오류 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -69,6 +69,18 @@ spring:
             enable: true
           timeout: 5000
           connectiontimeout: 5000
+  # RabbitMQ 설정 추가
+  rabbitmq:
+    host: localhost  # 또는 실제 RabbitMQ 서버 주소
+    port: 5672
+    username: guest
+    password: guest
+
+  # 채팅 설정 추가
+  chat:
+    queue:
+      name: chat.queue
+
   data:
     redis:
       host: master.sooktin-redis.dvwzww.apn2.cache.amazonaws.com


### PR DESCRIPTION
## 📌 이슈 번호

x

## 💻 작업 내용

해당 수정 사항은 EC2 내에서 애플리케이션 빌드 오류를 해결하기 위한 단기 해결책입니다
- [x] RabbitMQ 설정을 production 레벨에 추가


## 📢 기타 사항

- 장기적인 해결책을 위해 RabbitMQ가 어디에 위치할 것인지 (ex. 새로운 EC2를 생성하여 분리할 것인지, AWS MQ로 마이그레이션 할 것인지 등등) 추후 논의
- 현재는 설정 오류로 인한 빌드 실패를 해결하기 위한 해결책으로, 설정만 있고 실제 RabbitMQ가 없으니 애플리케이션이 계속해서 RabbitMQ에 연결을 시도하고 실패하는 상황이 발생할 수 있음
    - RabbitMQ의 위치에 대한 논의가 빠르게 이루어지지 않을 경우 오류 로그가 쌓일 우려가 있으니 해당 논의가 기말 이전에 이루어지지 않을 경우 RabbitMQ는 조건부로 실행되게끔 코드 레벨 수정이 이루어질 예정
